### PR TITLE
PHPMyAdmin didn't extract

### DIFF
--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -88,7 +88,7 @@ vagrantfile-local:
     extrascripts:
         phpmyadmin:
             install: 1
-            source_url: https://files.phpmyadmin.net/phpMyAdmin/4.5.1/phpMyAdmin-4.5.1-english.zip
+            source_url: https://files.phpmyadmin.net/phpMyAdmin/4.5.1/phpMyAdmin-4.5.1-english.tar.gz
         pml:
             install: 1
             source_url: https://github.com/potsky/PimpMyLog/tarball/master


### PR DESCRIPTION
After this change things seemed to work out ok. You were downloading the zip as a .tar.gz file and then running tar to extract it - so whilst it didn't ever error - no files were extracted.